### PR TITLE
feat: add fuel price z-score indicators

### DIFF
--- a/src/components/map/layers/custom/FuelPricesLayer.tsx
+++ b/src/components/map/layers/custom/FuelPricesLayer.tsx
@@ -26,7 +26,7 @@ export function FuelPricesLayer({ bounds }: FuelPricesLayerProps) {
 
     return (
       <Marker key={pfs.node_id} position={[pfs.location.latitude, pfs.location.longitude]} icon={icon}>
-        <PetrolFillingStationPopup data={pfs} />
+        <PetrolFillingStationPopup data={pfs} stats={data?.statistics} />
       </Marker>
     );
   });

--- a/src/hooks/useCurrentLocation.ts
+++ b/src/hooks/useCurrentLocation.ts
@@ -16,9 +16,7 @@ interface UseCurrentLocationReturnType {
   location: LocationDetails;
 }
 
-export function useCurrentLocation(
-  duration: number = 180_000,
-): UseCurrentLocationReturnType {
+export function useCurrentLocation(duration: number = 180_000): UseCurrentLocationReturnType {
   const [locationDetails, setLocationDetails] = useState<LocationDetails>({
     active: false,
     pending: true,
@@ -81,7 +79,7 @@ export function useCurrentLocation(
         active: true,
       }));
     },
-    [duration, map],
+    [duration, map]
   );
 
   return { activate, location: locationDetails };

--- a/src/hooks/useErrorToast.test.ts
+++ b/src/hooks/useErrorToast.test.ts
@@ -36,7 +36,7 @@ describe("useErrorToast", () => {
 
     renderHook(() => useErrorToast("test-id", "Test Title", error));
 
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(toaster.create).toHaveBeenCalledTimes(1);
     expect(toaster.create).toHaveBeenCalledWith({
@@ -58,7 +58,7 @@ describe("useErrorToast", () => {
       initialProps: { error: error1 },
     });
 
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(toaster.create).toHaveBeenCalledTimes(1);
     expect(toaster.create).toHaveBeenLastCalledWith({
@@ -72,7 +72,7 @@ describe("useErrorToast", () => {
 
     rerender({ error: error2 });
 
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(toaster.create).toHaveBeenCalledTimes(2);
     expect(toaster.create).toHaveBeenLastCalledWith({
@@ -91,7 +91,7 @@ describe("useErrorToast", () => {
 
     renderHook(() => useErrorToast("custom-id", "Custom Title", error));
 
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(toaster.create).toHaveBeenCalledWith({
       id: "custom-id",
@@ -114,13 +114,13 @@ describe("useErrorToast", () => {
       }
     );
 
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(toaster.create).toHaveBeenCalledTimes(1);
 
     rerender({ error: null });
 
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(toaster.create).toHaveBeenCalledTimes(1); // Should not be called again
   });

--- a/src/services/placenames/index.test.ts
+++ b/src/services/placenames/index.test.ts
@@ -1,21 +1,21 @@
-import axios from 'axios';
-import { vi } from 'vitest';
+import axios from "axios";
+import { vi } from "vitest";
 
 // Mock the entire module
-vi.mock('axios');
+vi.mock("axios");
 
 const mockEnv = {
-  VITE_PLACENAMES_API_URL: 'https://example.com',
+  VITE_PLACENAMES_API_URL: "https://example.com",
 };
 
-describe('suggest', () => {
+describe("suggest", () => {
   beforeEach(() => {
     Object.assign(import.meta.env, mockEnv);
     vi.resetModules();
   });
 
-  it('should call the correct API endpoint and return data', async () => {
-    const mockData = { results: ['result1', 'result2'] };
+  it("should call the correct API endpoint and return data", async () => {
+    const mockData = { results: ["result1", "result2"] };
     const mockGet = vi.fn().mockResolvedValue({ data: mockData });
     const createSpy = vi
       .spyOn(axios, "create")
@@ -25,27 +25,27 @@ describe('suggest', () => {
     const result = await suggest("test-prefix", 5);
 
     expect(createSpy).toHaveBeenCalledWith({
-      baseURL: 'https://example.com',
+      baseURL: "https://example.com",
       timeout: 3000,
     });
 
-    expect(mockGet).toHaveBeenCalledWith('/v1/place-names/prefix/test-prefix', {
+    expect(mockGet).toHaveBeenCalledWith("/v1/place-names/prefix/test-prefix", {
       params: { max_results: 5 },
     });
 
     expect(result).toEqual(mockData);
   });
 
-  it('should throw an error if the API URL is not defined', async () => {
+  it("should throw an error if the API URL is not defined", async () => {
     // Unset the environment variable
     delete import.meta.env.VITE_PLACENAMES_API_URL;
 
     // Use a try-catch block to assert that an error is thrown
     try {
-      await import('./index');
+      await import("./index");
     } catch (error) {
       if (error instanceof Error) {
-        expect(error.message).toBe('No Place Names API URL specified');
+        expect(error.message).toBe("No Place Names API URL specified");
       }
     }
   });

--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -1,51 +1,51 @@
-import { dateReviver, formatDate } from './dates';
+import { dateReviver, formatDate } from "./dates";
 
-describe('dateReviver', () => {
-  it('should return a Date object for a valid ISO 8601 string', () => {
-    const dateString = '2025-10-22T10:00:00Z';
+describe("dateReviver", () => {
+  it("should return a Date object for a valid ISO 8601 string", () => {
+    const dateString = "2025-10-22T10:00:00Z";
     const expectedDate = new Date(dateString);
-    expect(dateReviver('key', dateString)).toEqual(expectedDate);
+    expect(dateReviver("key", dateString)).toEqual(expectedDate);
   });
 
-  it('should return the original value for a non-ISO 8601 string', () => {
-    const value = 'not a date';
-    expect(dateReviver('key', value)).toBe(value);
+  it("should return the original value for a non-ISO 8601 string", () => {
+    const value = "not a date";
+    expect(dateReviver("key", value)).toBe(value);
   });
 
-  it('should return the original value for a non-string value', () => {
+  it("should return the original value for a non-string value", () => {
     const value = 123;
-    expect(dateReviver('key', value)).toBe(value);
+    expect(dateReviver("key", value)).toBe(value);
   });
 });
 
-describe('formatDate', () => {
-  it('should return undefined for an undefined date', () => {
+describe("formatDate", () => {
+  it("should return undefined for an undefined date", () => {
     expect(formatDate(undefined)).toBeUndefined();
   });
 
-  it('should format a Date object with a time other than midnight', () => {
-    const date = new Date('2025-10-22T10:00:00Z');
-    const expected = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+  it("should format a Date object with a time other than midnight", () => {
+    const date = new Date("2025-10-22T10:00:00Z");
+    const expected = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date);
     expect(formatDate(date)).toBe(expected);
   });
 
-  it('should format a string date with a time other than midnight', () => {
-    const dateString = '2025-10-22T10:00:00Z';
+  it("should format a string date with a time other than midnight", () => {
+    const dateString = "2025-10-22T10:00:00Z";
     const date = new Date(dateString);
-    const expected = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+    const expected = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date);
     expect(formatDate(dateString)).toBe(expected);
   });
 
-  it('should format a Date object at midnight as just the date', () => {
-    const date = new Date('2025-10-22T00:00:00Z');
-    const expected = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date);
+  it("should format a Date object at midnight as just the date", () => {
+    const date = new Date("2025-10-22T00:00:00Z");
+    const expected = new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(date);
     expect(formatDate(date)).toBe(expected);
   });
 
-  it('should format a string date at midnight as just the date', () => {
-    const dateString = '2025-10-22T00:00:00Z';
+  it("should format a string date at midnight as just the date", () => {
+    const dateString = "2025-10-22T00:00:00Z";
     const date = new Date(dateString);
-    const expected = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date);
+    const expected = new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(date);
     expect(formatDate(dateString)).toBe(expected);
   });
 });


### PR DESCRIPTION
Introduce a visual indicator to the fuel price table that highlights whether a price is competitive or overpriced based on statistical analysis.

*   Display a `FaRegThumbsUp` (green) for prices with a **z-score**
    $\leq -0.5$ (good price).
*   Display a `FaRegThumbsDown` (red) for prices with a **z-score**
    $\geq 0.5$ (overpriced).
*   Includes tooltips explaining the rating and the exact z-score.
*   Standardize code formatting across various hooks and test files.

```mermaid
sequenceDiagram
    participant Layer as FuelPricesLayer
    participant Popup as PetrolFillingStationPopup
    participant Table as PricesTable
    participant Ind as ZScoreIndicator

    Layer->>Popup: data + statistics
    Popup->>Table: fuel_prices + statistics
    Table->>Ind: price + statistics
    Note over Ind: Calculate (price - avg) / std_dev
    Ind-->>Table: Return Thumbs Up/Down/Null
```
<img width="395" height="397" alt="Screenshot 2026-02-21 at 19 36 27" src="https://github.com/user-attachments/assets/918af7f4-69d7-4a5a-8b26-c432f4f263b8" />
